### PR TITLE
Fix documentation errors when importing vmath from another library

### DIFF
--- a/src/vmath.nim
+++ b/src/vmath.nim
@@ -553,7 +553,7 @@ proc ivec4*(uvec4: Uvec4): Ivec4 =
 proc uvec4*(ivec4: Ivec4): Uvec4 =
   uvec4(ivec4.x.uint32, ivec4.y.uint32, ivec4.z.uint32, ivec4.w.uint32)
 
-when not defined(nimdoc):
+when not defined(nimdoc) or not isMainModule:
   # TODO when https://github.com/nim-lang/Nim/issues/13063 is fixed use macros.
   include vmath/swizzle
 


### PR DESCRIPTION
If vmath is imported in another library, and some of the swizzling operations are used, then `nim doc` fails with errors about undeclared fields.
If I'm correct, this `not defined` clause is used to stop nimdoc from filling the documentation with swizzling operations when generating docs for this library.
However, this is an issue only when compiling docs for *this* library, with `vmath.nim` being the main module, for all the other libraries `vmath/swizzle` should be included. Adding this fixed the problem for me, and as far as I can tell it shouldn't break anything with the docs here either