### PR TITLE
Signed angle 2D

### DIFF
--- a/src/vmath.nim
+++ b/src/vmath.nim
@@ -1573,8 +1573,12 @@ proc angle*[T](a: GVec2[T]): T =
   ## Angle of a Vec2.
   arctan2(a.y, a.x)
 
-proc angle*[T; S: GVec2[T]|GVec3[T]](a, b: S): T =
-  ## Angle between 2 Vec2 or Vec3.
+proc angle*[T; S: GVec2[T]](a, b: S): T =
+  ## Angle between 2 Vec2.
+  arctan2(a.y*b.x - a.x*b.y, a.x*b.x + a.y*b.y)
+
+proc angle*[T; S: GVec3[T]](a, b: S): T =
+  ## Angle between 2 Vec3.
   var dot = dot(a, b)
   dot = dot / (a.length * b.length)
   # The cases of angle((1, 1), (-1, -1)) and its 3d counterpart

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -1160,12 +1160,12 @@ block:
   template gen2DTestsFor(constructor: untyped): void =
     doAssert angle(constructor(1, 0), constructor(1, 0)) ~= 0
     doAssert angle(constructor(1, 1), constructor(-1, -1)) ~= Pi
-    doAssert angle(constructor(1, 0), constructor(0, 1)) ~= Pi/2
-    doAssert angle(constructor(1, 0), constructor(-1, 0)) ~= Pi
+    doAssert angle(constructor(1, 0), constructor(0, 1)) ~= -Pi/2
+    doAssert angle(constructor(1, 0), constructor(-1, 0)) ~= -Pi
     doAssert angle(constructor(1, 1), constructor(1, -1)) ~= Pi/2
 
     # Edge cases:
-    doAssert angle(constructor(0, 0), constructor(1, 0)).isNaN()
+    doAssert angle(constructor(0, 0), constructor(1, 0)) ~= 0
 
   gen2DTestsFor vec2
   gen2DTestsFor dvec2


### PR DESCRIPTION
I spent a lot of time trying to figure out why my code wasn't working, before finally identifying the angle function as the cause of the error. I thought I had the latest version but I didn't so I missed the fix in #74 and eventually solved it myself.

Sometime later I thought I should contribute my fix, only this time I discovered that the problem had already been solved. However, upon updating I realized that the function in #74 discards the sign of the angle, which is unfortunate because that information is extremely useful for a lot of things.

This version keeps the sign information (+PI to -PI), with positive values in the CCW direction as is traditional.