### PR TITLE
Fix orthogonal vectors with mixed signs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ We run identical math operations across vmath, GLSL, [nim-glm](https://github.co
 | Quaternion to axis-angle   | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Matrix inverse             | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Cross product              | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Orthogonal vector          | ✅ | ❌ | ❌ | ❌ | ✅ |
 | Slerp                      | ✅ | ✅ | ✅ | ✅ | ✅ |
 | fromTwoVectors             | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Quat decomposition (sign)  | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -149,6 +150,8 @@ We run identical math operations across vmath, GLSL, [nim-glm](https://github.co
 ❌ **Perspective matrix**: Jolt Physics uses Z range `[0, 1]` (Vulkan/DirectX convention) while vmath uses Z range `[-1, 1]` (OpenGL convention). The X and Y scaling match, but Z-related elements differ.
 
 ❌ **Element access note**: Jolt does convention differs from vmath's math-style `[row, col]` interpretation it follows the DirectX/HLSL convention.
+
+❌ **Orthogonal vector note**: Jolt Physics provides `GetNormalizedPerpendicular()`. vmath's `orthogonal()` returns a perpendicular vector without normalizing it. GLSL and nim-GLM have no direct equivalent, while gl-matrix only computes one internally as part of `quat.rotationTo()`.
 
 # 2.x.x to 3.0.0 vmath breaking changes:
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ We run identical math operations across vmath, GLSL, [nim-glm](https://github.co
 
 ❌ **Orthogonal vector note**: Jolt Physics provides `GetNormalizedPerpendicular()`. vmath's `orthogonal()` returns a perpendicular vector without normalizing it. GLSL and nim-GLM have no direct equivalent, while gl-matrix only computes one internally as part of `quat.rotationTo()`.
 
+ℹ️ **fromTwoVectors note**: vmath's `fromTwoVectors(a, b)` normalizes its inputs and handles antiparallel vectors with an orthogonal fallback. gl-matrix exposes the equivalent `quat.rotationTo(out, a, b)`, assumes unit inputs, and handles nearly antiparallel vectors. Jolt Physics exposes `Quat::sFromTo(from, to)`, supports arbitrary vector lengths, and handles antiparallel and zero-length inputs. nim-GLM exposes `quat(u, v)`, but assumes unit inputs and does not special-case antiparallel vectors. GLSL has no built-in quaternion or `fromTwoVectors`; the conformance suite supplies its own implementation for comparison.
+
 # 2.x.x to 3.0.0 vmath breaking changes:
 
 Version `3.0.0` changed rotation to be CCW (counter-clockwise) and updated the quaternion conventions to match GLSL, GLM, gl-matrix. Added a multi-library conformance suite.

--- a/README.md
+++ b/README.md
@@ -153,8 +153,6 @@ We run identical math operations across vmath, GLSL, [nim-glm](https://github.co
 
 ❌ **Orthogonal vector note**: Jolt Physics provides `GetNormalizedPerpendicular()`. vmath's `orthogonal()` returns a perpendicular vector without normalizing it. GLSL and nim-GLM have no direct equivalent, while gl-matrix only computes one internally as part of `quat.rotationTo()`.
 
-ℹ️ **fromTwoVectors note**: vmath's `fromTwoVectors(a, b)` normalizes its inputs and handles antiparallel vectors with an orthogonal fallback. gl-matrix exposes the equivalent `quat.rotationTo(out, a, b)`, assumes unit inputs, and handles nearly antiparallel vectors. Jolt Physics exposes `Quat::sFromTo(from, to)`, supports arbitrary vector lengths, and handles antiparallel and zero-length inputs. nim-GLM exposes `quat(u, v)`, but assumes unit inputs and does not special-case antiparallel vectors. GLSL has no built-in quaternion or `fromTwoVectors`; the conformance suite supplies its own implementation for comparison.
-
 # 2.x.x to 3.0.0 vmath breaking changes:
 
 Version `3.0.0` changed rotation to be CCW (counter-clockwise) and updated the quaternion conventions to match GLSL, GLM, gl-matrix. Added a multi-library conformance suite.

--- a/src/vmath.nim
+++ b/src/vmath.nim
@@ -1908,14 +1908,14 @@ proc quatInverse*[T](q: GVec4[T]): GVec4[T] =
 proc orthogonal*[T](v: GVec3[T]): GVec3[T] =
   ## Returns orthogonal vector to given vector.
   let
-    v = abs(v)
+    vAbs = abs(v)
     other: type(v) =
-      if v.x < v.y:
-        if v.x < v.z:
+      if vAbs.x < vAbs.y:
+        if vAbs.x < vAbs.z:
           gvec3(T(1), 0, 0) # X_AXIS
         else:
           gvec3(T(0), 0, 1) # Z_AXIS
-      elif v.y < v.z:
+      elif vAbs.y < vAbs.z:
         gvec3(T(0), 1, 0)   # Y_AXIS
       else:
         gvec3(T(0), 0, 1)   # Z_AXIS

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -772,10 +772,10 @@ suite "quaternion nlerp":
     check dist(nl, sl) < 0.01f
 
 suite "orthogonal vector":
-  test "orthogonal is perpendicular to abs(v)":
-    # orthogonal() uses abs(v) internally, so result is perpendicular to abs(v)
+  test "orthogonal is perpendicular to v":
     for v in [vec3(1, 0, 0), vec3(0, 1, 0), vec3(0, 0, 1),
-              vec3(1, 1, 0), vec3(1, 1, 1), vec3(3, 2, 7)]:
+              vec3(1, 1, 0), vec3(1, 1, 1), vec3(3, 2, 7),
+              vec3(0, -1, 1), vec3(-3, 2, -7)]:
       let o = orthogonal(v)
       check abs(dot(v, o)) < 1e-5f
 

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1166,6 +1166,13 @@ suite "fromTwoVectors":
       q = fromTwoVectors(a, b)
     check q.mat4() * a ~= b
 
+  test "antiparallel mixed-sign vectors":
+    let
+      a = normalize(vec3(0, -1, 1))
+      b = -a
+      q = fromTwoVectors(a, b)
+    check q.mat4() * a ~= b
+
   test "fromTwoVectors fuzz":
     for _ in 0 ..< 1000:
       let


### PR DESCRIPTION
The input was shadowed by abs(v), so orthogonal crossed the selected axis with the absolute-valued vector instead of the original signed vector. For mixed-sign inputs, the result could therefore have a nonzero dot product with the input.

Fixes #88